### PR TITLE
Fix #15 and #4

### DIFF
--- a/PRUNner/App/Controls/BasePlannerControl.axaml
+++ b/PRUNner/App/Controls/BasePlannerControl.axaml
@@ -111,7 +111,7 @@
                       SelectedItem="{Binding ActiveBase.CoGCBonus}" Width="175" />
         </StackPanel>
 
-        <StackPanel Grid.Row="3" Grid.Column="0" Margin="0,20,0,0">
+        <StackPanel Grid.Row="3" Grid.Column="0" Margin="0,20,0,30">
             <TextBlock Text="Experts" Classes="h2" HorizontalAlignment="Center" />
             <controls:ExpertControl DataContext="{Binding ActiveBase.ExpertAllocation.Agriculture}" />
             <controls:ExpertControl DataContext="{Binding ActiveBase.ExpertAllocation.Chemistry}" />

--- a/PRUNner/App/ViewModels/MainWindowViewModel.cs
+++ b/PRUNner/App/ViewModels/MainWindowViewModel.cs
@@ -132,7 +132,13 @@ namespace PRUNner.App.ViewModels
             basePlanner.SetActiveBase(planetaryBase);
 
             var window = new Window();
-            window.Content = basePlanner;
+            window.Content = new ScrollViewer
+            {
+                HorizontalScrollBarVisibility = Avalonia.Controls.Primitives.ScrollBarVisibility.Visible,
+                VerticalScrollBarVisibility = Avalonia.Controls.Primitives.ScrollBarVisibility.Visible,
+                AllowAutoHide = false,
+                Content = basePlanner
+            };
             window.Width = 1800;
             window.Height = 850;
             window.Icon = (Application.Current.ApplicationLifetime as ClassicDesktopStyleApplicationLifetime)?.MainWindow.Icon;

--- a/PRUNner/App/Views/MainWindow.axaml
+++ b/PRUNner/App/Views/MainWindow.axaml
@@ -14,24 +14,24 @@
         <viewModels:MainWindowViewModel />
     </Design.DataContext>
 
+  <ScrollViewer HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Visible" AllowAutoHide="false">
     <DockPanel>
-        <Menu DockPanel.Dock="Top">
-            <MenuItem Header="Empire Overview" Command="{Binding ViewEmpire}" />
-            <MenuItem Header="Base Planner" Command="{Binding ViewBasePlanner}" />
-            <MenuItem Header="Planet Finder" Command="{Binding ViewPlanetFinder}" />
-            <MenuItem Width="500" />
-            <MenuItem Header="Update Price Data" Command="{Binding UpdatePriceData}" />
-            <MenuItem Width="500" />
-            <MenuItem Header="Save" Command="{Binding SaveToDisk}" HorizontalAlignment="Right" />
-            <MenuItem Header="Load" Command="{Binding LoadFromDisk}" HorizontalAlignment="Right"  />
-        </Menu>
+      <Menu DockPanel.Dock="Top" HorizontalAlignment="Left">
+        <MenuItem Header="Empire Overview" Command="{Binding ViewEmpire}" />
+        <MenuItem Header="Base Planner" Command="{Binding ViewBasePlanner}" />
+        <MenuItem Header="Planet Finder" Command="{Binding ViewPlanetFinder}" />
+        <MenuItem MinWidth="100"/>
+        <MenuItem Header="Update Price Data" Command="{Binding UpdatePriceData}" />
+        <MenuItem MinWidth="100"/>
+        <MenuItem Header="Save" Command="{Binding SaveToDisk}" HorizontalAlignment="Right" />
+        <MenuItem Header="Load" Command="{Binding LoadFromDisk}" HorizontalAlignment="Right"  />
+      </Menu>
 
-        <ContentControl DockPanel.Dock="Top" Margin="5" Content="{Binding ActiveView}" />
+      <ContentControl DockPanel.Dock="Top" Margin="5" Content="{Binding ActiveView}" />
 
-        <Border DockPanel.Dock="Bottom" Background="LightGray" Height="16" VerticalAlignment="Bottom">
-            <TextBlock Text="{Binding StatusBar}" VerticalAlignment="Center" HorizontalAlignment="Left" FontSize="10" Margin="3,0,0,0"/>
-        </Border>
-        
+      <Border DockPanel.Dock="Bottom" Background="LightGray" Height="32" VerticalAlignment="Bottom">
+        <TextBlock Text="{Binding StatusBar}" VerticalAlignment="Top" HorizontalAlignment="Left" FontSize="10" Margin="3,0,0,0"/>
+      </Border>
     </DockPanel>
-
+  </ScrollViewer>
 </Window>


### PR DESCRIPTION
- Fix FIOImport to use /planet/allplanets/full instead of iterating through individual planets. 
- Wrap the entire MainWindow in a ScrollViewer and make it always visible--it's not the best solution, but it's better than no scrollbar at all. 
  - For example, the bottom docked border needs to have a fixed 32 height instead since it was being hidden by the scrollbar and it doesn't move along with the window any more, which sucks...but I don't know of a better way to fix it. 
- Misc other fixes:
  - Gave the experts grid a larger margin on the bottom
  - Made the menu a little narrower