### PR TITLE
Building Custom Efficiency - Initial Commit

### DIFF
--- a/PRUNner/App/Controls/ProductionLineControl.axaml
+++ b/PRUNner/App/Controls/ProductionLineControl.axaml
@@ -20,6 +20,13 @@
             <controls:BuildingCounterControl />
             <Button HorizontalAlignment="Center" Content="Add Recipe" Command="{Binding AddProduction}" />
         </StackPanel>
+		<StackPanel VerticalAlignment="Center">
+			<TextBlock VerticalAlignment="Center" Text="Efficiency" Margin="0,0,5,0" />
+			<StackPanel Orientation="Horizontal">
+			    <TextBox VerticalAlignment="Center" Text="{Binding SetEfficiency, Converter={StaticResource TextToProductionLinePercentage}}" Width="15" ToolTip.Tip="Override Efficiency Value (0 = Use Default) - Use to take into account Building Condition and/or Corp HQ bonuses" />
+			    <TextBlock VerticalAlignment="Center" Text="%" Margin="0,0,5,0" />
+			</StackPanel>
+		</StackPanel>
         <ItemsControl Items="{Binding Production}" VerticalAlignment="Top">
             <ItemsControl.ItemsPanel>
                 <ItemsPanelTemplate>

--- a/PRUNner/Backend/BasePlanner/PlanetBuilding.cs
+++ b/PRUNner/Backend/BasePlanner/PlanetBuilding.cs
@@ -28,6 +28,7 @@ namespace PRUNner.Backend.BasePlanner
         public ImmutableArray<MaterialIO> BuildingMaterials { get; init; } 
         
         public double Efficiency { get; private set; }
+        public double SetEfficiency { get; private set; }
         public double BuildingCost { get; private set; }
         public double DailyCostForRepairs { get; private set; }
 
@@ -74,6 +75,7 @@ namespace PRUNner.Backend.BasePlanner
 
             this.WhenPropertyChanged(x => x.Amount).Subscribe(value => RecalculateBuildingCosts());
             RecalculateBuildingCosts();
+           
         }
 
         private void RecalculateBuildingCosts()
@@ -132,7 +134,7 @@ namespace PRUNner.Backend.BasePlanner
         }
 
         public void UpdateProductionEfficiency(WorkforceSatisfaction workforceSatisfaction,
-            ExpertAllocation expertAllocation, CoGCBonusType cogcBonusType, Headquarters hq)
+            ExpertAllocation expertAllocation, CoGCBonusType cogcBonusType, Headquarters hq, double setEfficiency)
         {
             var expertBonus = expertAllocation.GetEfficiencyBonus(Building.Expertise);
             var hqBonus = hq.GetFactionEfficiencyFactorForIndustry(Building.Expertise);
@@ -145,6 +147,10 @@ namespace PRUNner.Backend.BasePlanner
             satisfaction += workforceSatisfaction.Scientists * Building.WorkforceRatio.Scientists;
 
             Efficiency = satisfaction * (1 + expertBonus) * (1 + hqBonus) * (1 + cogcBonus) * _fertilityBonus;
+            if (double.IsFinite(setEfficiency) && setEfficiency > 0)
+            {
+                Efficiency = setEfficiency/100;
+            }
             if (AvailableRecipes == null)
             {
                 return;

--- a/PRUNner/Backend/BasePlanner/PlanetaryBase.cs
+++ b/PRUNner/Backend/BasePlanner/PlanetaryBase.cs
@@ -33,6 +33,7 @@ namespace PRUNner.Backend.BasePlanner
         
         public ProvidedConsumables ProvidedConsumables { get; } = new();
         [Reactive] public CoGCBonusType CoGCBonus { get; set; } = CoGCBonusType.None;
+        [Reactive] public SetEfficiency SetEfficiency { get; set; }
         
         public int AreaTotal { get; } = Constants.BaseArea;
         [Reactive] public int AreaDeveloped { get; private set; }
@@ -79,6 +80,7 @@ namespace PRUNner.Backend.BasePlanner
 
             WorkforceSatisfaction.Changed.Subscribe(_ => RecalculateBuildingEfficiencies());
             Empire.Headquarters.Changed.Subscribe(_ => RecalculateBuildingEfficiencies());
+
             
             // TODO: Figure out why this here does not work, then use Observable.Merge instead of subscribing a dozen times.
             // ExpertAllocation.Changed.Subscribe(_ => RecalculateBuildingEfficiencies());
@@ -107,7 +109,7 @@ namespace PRUNner.Backend.BasePlanner
             
             foreach (var building in ProductionBuildings)
             {
-                building.UpdateProductionEfficiency(WorkforceSatisfaction, ExpertAllocation, CoGCBonus, Empire.Headquarters);
+                building.UpdateProductionEfficiency(WorkforceSatisfaction, ExpertAllocation, CoGCBonus, Empire.Headquarters, building.SetEfficiency);
             }
             
             OnProductionChange();
@@ -119,7 +121,8 @@ namespace PRUNner.Backend.BasePlanner
             if (addedBuilding == null)
             {
                 addedBuilding = PlanetBuilding.FromProductionBuilding(this, Planet, building);
-                addedBuilding.Changed.Subscribe(_ => OnBuildingChange());
+                addedBuilding.Changed.Subscribe(_ => { OnBuildingChange(); });
+                
                 addedBuilding.OnProductionUpdate += OnProductionChange;
                 ProductionBuildings.Add(addedBuilding);
             }
@@ -143,12 +146,15 @@ namespace PRUNner.Backend.BasePlanner
             ProductionTable.Update(ProductionBuildings);
 
             RecalculateProfits();
-            
+
+
             VolumeIn = ProductionTable.Inputs.Sum(x => x.Volume);
             WeightIn = ProductionTable.Inputs.Sum(x => x.Weigth);
             
             VolumeOut = ProductionTable.Outputs.Sum(x => x.Volume);
             WeightOut = ProductionTable.Outputs.Sum(x => x.Weigth);
+
+
         }
 
         private void RecalculateWorkforce()
@@ -239,5 +245,9 @@ namespace PRUNner.Backend.BasePlanner
 
             ReturnOfInvestment = ColonyCosts / NetProfit;
         }
+    }
+
+    public class SetEfficiency
+    {
     }
 }

--- a/PRUNner/Backend/UserDataParser/UserDataWriter.cs
+++ b/PRUNner/Backend/UserDataParser/UserDataWriter.cs
@@ -140,6 +140,7 @@ namespace PRUNner.Backend.UserDataParser
                 var buildingObject = new JObject();
                 buildingObject.Add(nameof(PlanetBuilding.Building), building.Building.Ticker);
                 buildingObject.Add(nameof(PlanetBuilding.Amount), building.Amount);
+                buildingObject.Add(nameof(PlanetBuilding.SetEfficiency), building.SetEfficiency);
 
                 var productionArray = new JArray();
                 foreach (var production in building.Production)


### PR DESCRIPTION
- Enables setting individual buildings' Efficiency levels to override existing efficiency level calculations, can be obtained from ingame display.
- Setting the Efficiency at 0 will default to the auto-calculated efficiency.

![image](https://user-images.githubusercontent.com/55260779/166405959-95a0206d-f0ed-4887-bc7f-9d620a8d84db.png)

Due to my non-familiarity with C# and the general syntax of the language, there are a few outstanding features and bugs:
- Typing in the Efficiency box will not update production until one of the workforce or infrastructure building sections are toggled.
- Does not save or load custom efficiencies entered yet.

Feel free to edit this as required or if you have suggestions on where I can implement the above, I can also make edits to this PR before it's okay to merge.