### PR TITLE
Corp HQ Bonus Checkbox Addition

### DIFF
--- a/PRUNner/App/Controls/BasePlannerControl.axaml
+++ b/PRUNner/App/Controls/BasePlannerControl.axaml
@@ -104,11 +104,16 @@
             </Grid>
         </StackPanel>
 
-        <StackPanel Grid.Row="2" Grid.Column="0" Margin="0,20,0,0">
+        <StackPanel Grid.Row="2" Grid.Column="0" Margin="0,20,0,0" HorizontalAlignment="Center">
             <TextBlock Text="CoGC Bonus" Classes="h2" HorizontalAlignment="Center" />
             <ComboBox HorizontalAlignment="Center"
                       Items="{Binding Source={markupExtensions:EnumBindingSource {x:Type enums:CoGCBonusType}}}"
                       SelectedItem="{Binding ActiveBase.CoGCBonus}" Width="175" />
+
+			<StackPanel Orientation="Horizontal" Margin="10,5,0,0">
+			    <TextBlock Text="Corp HQ Bonus" VerticalAlignment="Center" Classes="h2" Margin="0,0,30,0" />
+			    <CheckBox VerticalAlignment="Center" IsChecked="{Binding ActiveBase.CorpHQBonus}" ToolTip.Tip="Check if this planet is your Corporation's HQ (+10% Efficiency)"/>
+			</StackPanel>
         </StackPanel>
 
         <StackPanel Grid.Row="3" Grid.Column="0" Margin="0,20,0,30">

--- a/PRUNner/Backend/BasePlanner/PlanetBuilding.cs
+++ b/PRUNner/Backend/BasePlanner/PlanetBuilding.cs
@@ -136,7 +136,7 @@ namespace PRUNner.Backend.BasePlanner
         }
 
         public void UpdateProductionEfficiency(WorkforceSatisfaction workforceSatisfaction,
-            ExpertAllocation expertAllocation, CoGCBonusType cogcBonusType, Headquarters hq)
+            ExpertAllocation expertAllocation, CoGCBonusType cogcBonusType, Headquarters hq, bool corpHQBonus)
         {
             if (AdvancedBuildingConfiguration.UseEfficiencyOverride)
             {
@@ -147,6 +147,7 @@ namespace PRUNner.Backend.BasePlanner
                 var expertBonus = expertAllocation.GetEfficiencyBonus(Building.Expertise);
                 var hqBonus = hq.GetFactionEfficiencyFactorForIndustry(Building.Expertise);
                 var cogcBonus = GetCoGCBonus(cogcBonusType);
+                var corpBonus = corpHQBonus ? 0.1 : 0;
                 var satisfaction = 0d;
                 satisfaction += workforceSatisfaction.Pioneers * Building.WorkforceRatio.Pioneers;
                 satisfaction += workforceSatisfaction.Settlers * Building.WorkforceRatio.Settlers;
@@ -154,7 +155,7 @@ namespace PRUNner.Backend.BasePlanner
                 satisfaction += workforceSatisfaction.Engineers * Building.WorkforceRatio.Engineers;
                 satisfaction += workforceSatisfaction.Scientists * Building.WorkforceRatio.Scientists;
 
-                Efficiency = satisfaction * (1 + expertBonus) * (1 + hqBonus) * (1 + cogcBonus) * (AdvancedBuildingConfiguration.ProductionLineCondition / 100) * _fertilityBonus;
+                Efficiency = satisfaction * (1 + expertBonus) * (1 + hqBonus) * (1 + cogcBonus) * (1 + corpBonus) * (AdvancedBuildingConfiguration.ProductionLineCondition / 100) * _fertilityBonus;
             }
 
             if (AvailableRecipes == null)

--- a/PRUNner/Backend/BasePlanner/PlanetaryBase.cs
+++ b/PRUNner/Backend/BasePlanner/PlanetaryBase.cs
@@ -40,6 +40,7 @@ namespace PRUNner.Backend.BasePlanner
         [Reactive] public double ProfitPerDay { get; private set; }
         
         [Reactive] public bool IncludeCoreModuleInColonyCosts { get; set; }
+        [Reactive] public bool CorpHQBonus { get; set; }
         [Reactive] public double ColonyCosts { get; private set; }
         [Reactive] public double TotalDailyRepairCosts { get; private set; }
         [Reactive] public double NetProfit { get; private set; }
@@ -93,6 +94,7 @@ namespace PRUNner.Backend.BasePlanner
             ExpertAllocation.ResourceExtraction.Changed.Subscribe(_ => RecalculateBuildingEfficiencies());
 
             this.WhenPropertyChanged(x => x.CoGCBonus).Subscribe(_ => RecalculateBuildingEfficiencies());
+            this.WhenPropertyChanged(x => x.CorpHQBonus).Subscribe(_ => RecalculateBuildingEfficiencies());
             this.WhenPropertyChanged(x => x.IncludeCoreModuleInColonyCosts).Subscribe(_ => RecalculateProfits());
          
             FinishLoading();
@@ -107,7 +109,7 @@ namespace PRUNner.Backend.BasePlanner
             
             foreach (var building in ProductionBuildings)
             {
-                building.UpdateProductionEfficiency(WorkforceSatisfaction, ExpertAllocation, CoGCBonus, Empire.Headquarters);
+                building.UpdateProductionEfficiency(WorkforceSatisfaction, ExpertAllocation, CoGCBonus, Empire.Headquarters, CorpHQBonus);
             }
             
             OnProductionChange();

--- a/PRUNner/Backend/UserDataParser/UserDataReader.cs
+++ b/PRUNner/Backend/UserDataParser/UserDataReader.cs
@@ -118,6 +118,7 @@ namespace PRUNner.Backend.UserDataParser
 
             var cogcString = obj.GetValue(nameof(PlanetaryBase.CoGCBonus))?.ToObject<string>() ?? CoGCBonusType.None.ToString();
             result.CoGCBonus = Enum.Parse<CoGCBonusType>(cogcString, true);
+            result.CorpHQBonus = obj.GetValue(nameof(PlanetaryBase.CorpHQBonus))?.ToObject<bool>() ?? false;
             result.IncludeCoreModuleInColonyCosts = obj.GetValue(nameof(PlanetaryBase.IncludeCoreModuleInColonyCosts))?.ToObject<bool>() ?? false;
 
             ReadInfrastructureBuildings((JObject) obj[nameof(PlanetaryBase.InfrastructureBuildings)]!, result.InfrastructureBuildings);

--- a/PRUNner/Backend/UserDataParser/UserDataWriter.cs
+++ b/PRUNner/Backend/UserDataParser/UserDataWriter.cs
@@ -89,6 +89,7 @@ namespace PRUNner.Backend.UserDataParser
             
             result.Add(nameof(PlanetaryBase.Planet), planetaryBase.Planet.Id);
             result.Add(nameof(PlanetaryBase.CoGCBonus), planetaryBase.CoGCBonus.ToString());
+            result.Add(nameof(PlanetaryBase.CorpHQBonus), planetaryBase.CorpHQBonus);
             result.Add(nameof(PlanetaryBase.PriceOverrides), WritePriceOverrides(planetaryBase.PriceOverrides));
             
             result.Add(nameof(PlanetaryBase.InfrastructureBuildings), WriteInfrastructureBuildings(planetaryBase.InfrastructureBuildings));


### PR DESCRIPTION
- In Base Planner view, add a Corp HQ Bonus checkbox (+10% efficiency boost planet-wide if on your corporation's HQ).

![image](https://user-images.githubusercontent.com/55260779/166821364-fa4d26d6-52e5-430a-adb1-308d084f543f.png)
