### PR TITLE
Additional Dark Mode and Visual Tweaks

### DIFF
--- a/PRUNner/App/ViewModels/MainWindowViewModel.cs
+++ b/PRUNner/App/ViewModels/MainWindowViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
@@ -120,13 +121,30 @@ namespace PRUNner.App.ViewModels
             if (Application.Current == null)
                 return;
 
+            FluentTheme fluentTheme = GetCurrentFluentTheme();
+            FluentThemeMode newFluentThemeMode =
+                fluentTheme.Mode == FluentThemeMode.Dark ? FluentThemeMode.Light : FluentThemeMode.Dark;
+            SetTheme(newFluentThemeMode);
+        }
+
+        //I would really prefer a better way of getting the current FluentTheme
+        private FluentTheme GetCurrentFluentTheme()
+        {
             foreach (IStyle style in Application.Current.Styles)
             {
                 if (!(style is FluentTheme)) continue;
 
                 FluentTheme theme = (FluentTheme)style;
-                theme.Mode = theme.Mode == FluentThemeMode.Dark ? FluentThemeMode.Light : FluentThemeMode.Dark;
+                return theme;
             }
+
+            throw new Exception("Unable to locate FluentTheme");
+        }
+
+        public void SetTheme(FluentThemeMode fluentThemeMode)
+        {
+            FluentTheme fluentTheme = GetCurrentFluentTheme();
+            fluentTheme.Mode = fluentThemeMode;
         }
         
         public void LogEventAction(LogEventInfo info, object[] objects)

--- a/PRUNner/App/Views/MainWindow.axaml
+++ b/PRUNner/App/Views/MainWindow.axaml
@@ -39,7 +39,7 @@
 
       <ContentControl DockPanel.Dock="Top" Margin="5" Content="{Binding ActiveView}" />
 
-      <Border DockPanel.Dock="Bottom" Background="LightGray" Height="32" VerticalAlignment="Bottom">
+      <Border DockPanel.Dock="Bottom" Height="32" VerticalAlignment="Bottom">
         <TextBlock Text="{Binding StatusBar}" VerticalAlignment="Top" HorizontalAlignment="Left" FontSize="10" Margin="3,0,0,0"/>
       </Border>
     </DockPanel>

--- a/PRUNner/App/Views/MainWindow.axaml
+++ b/PRUNner/App/Views/MainWindow.axaml
@@ -7,7 +7,7 @@
         x:Class="PRUNner.App.Views.MainWindow"
         Icon="/App/Assets/avalonia-logo.ico"
         CanResize="True"
-        Title="PRUNner" Width="1850" Height="1000"
+        Title="PRUNner" Width="1870" Height="1030"
         MaxHeight="99999" MaxWidth="99999">
 
     <Design.DataContext>

--- a/PRUNner/App/Views/PlanetFinderView.axaml
+++ b/PRUNner/App/Views/PlanetFinderView.axaml
@@ -24,7 +24,7 @@
                 </StackPanel>
                 
                 <StackPanel Orientation="Horizontal">
-                    <Button Content="🔎 Search" FontSize="27" Height="45" Width="140" Margin="10" HorizontalAlignment="Center"
+                    <Button Content="🔎 Search" FontSize="24" Height="45" Width="140" Margin="10" HorizontalAlignment="Center"
                             Command="{Binding Search}" />
                     <CheckBox IsChecked="{Binding MustBeFertile}" Margin="5, 0, 0, 0" >Fertile Soil</CheckBox>
                 </StackPanel>


### PR DESCRIPTION
For Issue #33 

- Fix for statusbar background in dark mode (it was staying grey and the text was hard to read)
- Theme toggle improvements & prep for remembering theme on restart (might be easier to restore the preferred theme at startup with a SetTheme() method)
- Fix for Search button text label truncation (on my Linux PC it's a "Searc" button currently, made the font a bit smaller)
- Slight increase to window size to hide base planner scrollbars (scrollbars were enabling on the base planner for me)