### PR TITLE
Sorting

### DIFF
--- a/PRUNner/App/Controls/BasePlannerControl.axaml
+++ b/PRUNner/App/Controls/BasePlannerControl.axaml
@@ -312,15 +312,17 @@
                            TextAlignment="Right" />
             </Grid>
             <StackPanel Grid.Row="2" Orientation="Horizontal">
-                <Button Width="55" Height="30" Command="{Binding ActiveBase.ProductionTable.SortByTicker}"
-                        HorizontalContentAlignment="Center" Content="" />
-                <Button Width="85" Command="{Binding ActiveBase.ProductionTable.SortByInputs}"
+                <Button Width="50" Height="30" Command="{Binding ActiveBase.ProductionTable.SortByTicker}"
+                        HorizontalContentAlignment="Center" Content="TCK" />
+                <Button Width="50" Height="30" Command="{Binding ActiveBase.ProductionTable.SortByCategory}"
+                        HorizontalContentAlignment="Center" Content="CAT" />
+                <Button Width="75" Command="{Binding ActiveBase.ProductionTable.SortByInputs}"
                         HorizontalContentAlignment="Center" Content="Inputs" />
-                <Button Width="85" Command="{Binding ActiveBase.ProductionTable.SortByOutputs}"
+                <Button Width="75" Command="{Binding ActiveBase.ProductionTable.SortByOutputs}"
                         HorizontalContentAlignment="Center" Content="Outputs" />
-                <Button Width="85" Command="{Binding ActiveBase.ProductionTable.SortByBalance}"
+                <Button Width="75" Command="{Binding ActiveBase.ProductionTable.SortByBalance}"
                         HorizontalContentAlignment="Center" Content="Balance" />
-                <Button Width="95" Command="{Binding ActiveBase.ProductionTable.SortByValue}"
+                <Button Width="75" Command="{Binding ActiveBase.ProductionTable.SortByValue}"
                         HorizontalContentAlignment="Center" Content="$/day" />
             </StackPanel>
             <Border Grid.Row="3" BorderThickness="1" BorderBrush="LightGray">

--- a/PRUNner/Backend/BasePlanner/PlanetProductionTable.cs
+++ b/PRUNner/Backend/BasePlanner/PlanetProductionTable.cs
@@ -57,6 +57,8 @@ namespace PRUNner.Backend.BasePlanner
                     }
                 }
             }
+
+            Sort();
             
             foreach (var row in Rows)
             {
@@ -110,30 +112,38 @@ namespace PRUNner.Backend.BasePlanner
             return row;
         }
         
-        private string _currentSortMode = "";
-        private void Sort(string sortModeName, SortOrder defaultSortOrder, Func<PlanetProductionRow, object> comparer)
+        private string _currentSortMode = nameof(SortByCategory);
+        private SortOrder _currentSortOrder = SortOrder.Ascending;
+        private Func<PlanetProductionRow, object> _currentSortComparer = x => x.Material.Category + "/" + x.Material.Name;
+
+        private void Sort()
         {
             List<PlanetProductionRow> result;
+            result = _currentSortOrder == SortOrder.Ascending
+                ? Rows.OrderBy(_currentSortComparer).ToList()
+                : Rows.OrderByDescending(_currentSortComparer).ToList();
+            Rows.Clear();
+            Rows.AddRange(result);
+        }
+
+        private void Sort(string sortModeName, SortOrder defaultSortOrder, Func<PlanetProductionRow, object> comparer)
+        {
             if (_currentSortMode.Equals(sortModeName))
             {
-                result = defaultSortOrder == SortOrder.Ascending 
-                    ? Rows.OrderByDescending(comparer).ToList()
-                    : Rows.OrderBy(comparer).ToList();
+                _currentSortOrder = SortOrder.Descending;
                 _currentSortMode = sortModeName + "Inverse";
             }
             else
             {
-                result = defaultSortOrder == SortOrder.Ascending 
-                    ? Rows.OrderBy(comparer).ToList()
-                    : Rows.OrderByDescending(comparer).ToList();
+                _currentSortOrder = SortOrder.Ascending;
                 _currentSortMode = sortModeName;
+                _currentSortComparer = comparer;
             }
-            
-            Rows.Clear();
-            Rows.AddRange(result);
+            Sort();
         }
         
         public void SortByTicker() => Sort(nameof(SortByTicker), SortOrder.Ascending, x => x.Material.Ticker);
+        public void SortByCategory() => Sort(nameof(SortByCategory), SortOrder.Ascending, x => x.Material.Category + "/" + x.Material.Name);
         public void SortByInputs() => Sort(nameof(SortByInputs), SortOrder.Descending, x => x.Inputs);
         public void SortByOutputs() => Sort(nameof(SortByOutputs), SortOrder.Descending, x => x.Outputs);
         public void SortByBalance() => Sort(nameof(SortByBalance), SortOrder.Descending, x => x.Balance);


### PR DESCRIPTION
This refactors the sort implementation a little to:

1. Support sorting by category, and set that as the default on the Base Planner screen
2. Sort the inputs/outputs list on base planner screen and resort whenever a recipe is added/removed (previously materials were sorted by the first recipe left-to-right that they appeared in)
3. Sort the production tables on the Empire View screen by category

I copied my changes from my working copy into Github via the Github web editor, so I hope it still builds!  Lmk if there's any code style I should be following.